### PR TITLE
Release v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-gateway-mqtt-proxy",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "BLE Gateway Data Processor - Receives data from April Brother BLE Gateway V4 and publishes to MQTT",
   "main": "src/index.js",
   "directories": {


### PR DESCRIPTION
Version bump for release v1.3.1

## Changes
- Bump version to v1.3.1 in package.json

## Release Process
1. Review and merge this PR
2. Run 
> ble-gateway-mqtt-proxy@1.3.1 release
> node scripts/release.js

[1m
🚀 BLE Gateway MQTT Proxy Release Helper
[0m
[34mℹ️  Existing release tags:[0m
[36m  tags/v1.3.0[0m
[36m  tags/v1.2.1[0m
[36m  tags/v1.2.0[0m
[36m  tags/v1.1[0m
[36m  tags/v1.0[0m
[34mℹ️  Latest release: tags/v1.3.0 (1.3.0)[0m
[34mℹ️  Checking current branch...[0m
[31m❌ You must be on the 'main' branch to create a release. Current branch: release/v1.3.1[0m
[31m❌ Please switch to main: git checkout main[0m to create the release tag
3. GitHub Actions will automatically build and publish the release

## Checklist
- [ ] Version number is correct
- [ ] All tests are passing
- [ ] Ready to release